### PR TITLE
Add configurable base controller class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ### Unrealeased
 
+*   Added `base_controller_class` configuration option to allow specifying a custom base controller for the ActiveAnalytics dashboard,
+    enhancing flexibility in diverse application architectures.
 *   Queue requests to reduce the load on database writes
 
     Database writes are slow. On large trafic applications it might overload the database.

--- a/README.md
+++ b/README.md
@@ -38,6 +38,15 @@ Add the route to ActiveAnalytics dashboard at the desired endpoint:
 # config/routes.rb
 mount ActiveAnalytics::Engine, at: "analytics"  # http://localhost:3000/analytics
 ```
+By default ActiveAnalytics will extend `ActionController::Base`, but you can specify a custom base controller for the ActiveAnalytics dashboard:
+
+```ruby
+# config/initializers/active_analytics.rb
+Rails.application.configure do
+  ActiveAnalytics.base_controller_class = "ApplicationController"
+end
+```
+
 
 The next step is to collect trafic and there is 2 options.
 

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ By default ActiveAnalytics will extend `ActionController::Base`, but you can spe
 ```ruby
 # config/initializers/active_analytics.rb
 Rails.application.configure do
-  ActiveAnalytics.base_controller_class = "ApplicationController"
+  ActiveAnalytics.base_controller_class = "AdminController"
 end
 ```
 

--- a/app/controllers/active_analytics/application_controller.rb
+++ b/app/controllers/active_analytics/application_controller.rb
@@ -1,5 +1,6 @@
 module ActiveAnalytics
-  class ApplicationController < ActionController::Base
+  class ApplicationController < ActiveAnalytics.base_controller_class.constantize
+    layout "active_analytics/application"
 
     private
 

--- a/lib/active_analytics.rb
+++ b/lib/active_analytics.rb
@@ -2,6 +2,8 @@ require "active_analytics/version"
 require "active_analytics/engine"
 
 module ActiveAnalytics
+  mattr_accessor :base_controller_class
+
   def self.redis_url=(string)
     @redis_url = string
   end

--- a/lib/active_analytics.rb
+++ b/lib/active_analytics.rb
@@ -2,7 +2,7 @@ require "active_analytics/version"
 require "active_analytics/engine"
 
 module ActiveAnalytics
-  mattr_accessor :base_controller_class
+  mattr_accessor :base_controller_class, default: "ActionController::Base"
 
   def self.redis_url=(string)
     @redis_url = string


### PR DESCRIPTION
Add `base_controller_class` accessor to ActiveAnalytics. I think this may help when using the mountable dashboard.